### PR TITLE
Code Cleanup

### DIFF
--- a/src/TcpServiceCore.Test/Program.cs
+++ b/src/TcpServiceCore.Test/Program.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using TcpServiceCore.Client;
 using TcpServiceCore.Communication;
@@ -35,7 +33,7 @@ namespace TcpServiceCore.Test
 
             await host.Open();
 
-            var client = await ChannelFactory<IService>.CreateProxy("localhost", 9091, config, true);
+            var client = await ChannelFactory<IService>.CreateProxy("localhost", 9091, config);
 
             using ((IClientChannel)client)
             {

--- a/src/TcpServiceCore.Test/Properties/AssemblyInfo.cs
+++ b/src/TcpServiceCore.Test/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following

--- a/src/TcpServiceCore.Test/Services/IService.cs
+++ b/src/TcpServiceCore.Test/Services/IService.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using TcpServiceCore.Attributes;
 
 namespace TcpServiceCore.Test.Services

--- a/src/TcpServiceCore.Test/Services/Service.cs
+++ b/src/TcpServiceCore.Test/Services/Service.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using TcpServiceCore.Attributes;
 using TcpServiceCore.Dispatching;

--- a/src/TcpServiceCore/Attributes/OperationContractAttribute.cs
+++ b/src/TcpServiceCore/Attributes/OperationContractAttribute.cs
@@ -1,12 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace TcpServiceCore.Attributes
 {
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
+    [AttributeUsage(AttributeTargets.Method, Inherited = false)]
     public class OperationContractAttribute : Attribute
     {
         public bool IsOneWay { get; set; }

--- a/src/TcpServiceCore/Attributes/ServiceBehaviorAttribute.cs
+++ b/src/TcpServiceCore/Attributes/ServiceBehaviorAttribute.cs
@@ -1,13 +1,9 @@
 ﻿using TcpServiceCore.Dispatching;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace TcpServiceCore.Attributes
 {
-    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+    [AttributeUsage(AttributeTargets.Class, Inherited = false)]
     public class ServiceBehaviorAttribute : Attribute
     {
         public InstanceContextMode InstanceContextMode { get; set; }

--- a/src/TcpServiceCore/Attributes/ServiceContractAttribute.cs
+++ b/src/TcpServiceCore/Attributes/ServiceContractAttribute.cs
@@ -1,12 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace TcpServiceCore.Attributes
 {
-    [AttributeUsage(AttributeTargets.Interface, AllowMultiple = false, Inherited = false)]
+    [AttributeUsage(AttributeTargets.Interface)]
     public class ServiceContractAttribute : Attribute
     {
     }

--- a/src/TcpServiceCore/Buffering/BufferManager.cs
+++ b/src/TcpServiceCore/Buffering/BufferManager.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace TcpServiceCore.Buffering
 {
@@ -10,13 +8,13 @@ namespace TcpServiceCore.Buffering
         public readonly int MaxBufferSize;
         public readonly int MaxBufferPoolSize;
 
-        int minSize = 128;
-        Dictionary<int, BufferPool> pools = new Dictionary<int, BufferPool>();
+        private const int minSize = 128;
+        readonly Dictionary<int, BufferPool> pools = new Dictionary<int, BufferPool>();
         
         public BufferManager(int maxBufferSize, int maxBufferPoolSize)
         {
-            var bsn = nameof(maxBufferSize);
-            var psn = nameof(maxBufferPoolSize);
+            const string bsn = nameof(maxBufferSize);
+            const string psn = nameof(maxBufferPoolSize);
 
             if (maxBufferSize <= minSize)
                 throw new Exception($"{bsn} must be positive greater than {minSize}");
@@ -25,8 +23,8 @@ namespace TcpServiceCore.Buffering
             if (maxBufferPoolSize < maxBufferSize)
                 throw new Exception($"{psn} can not be less than {bsn}");
 
-            this.MaxBufferSize = maxBufferSize;
-            this.MaxBufferPoolSize = maxBufferPoolSize;
+            MaxBufferSize = maxBufferSize;
+            MaxBufferPoolSize = maxBufferPoolSize;
 
             var poolSize = minSize / 2;
             do
@@ -38,15 +36,15 @@ namespace TcpServiceCore.Buffering
 
         public byte[] GetFitBuffer(int size)
         {
-            if (size > this.MaxBufferSize)
-                throw new Exception($"Received message is too big, max buffer size is {this.MaxBufferSize}");
+            if (size > MaxBufferSize)
+                throw new Exception($"Received message is too big, max buffer size is {MaxBufferSize}");
 
             if (size < minSize)
                 return new byte[size];
 
             var fitPoolIndex = (int)Math.Ceiling((double)size / minSize);
 
-            return this.pools[fitPoolIndex].GetBuffer();
+            return pools[fitPoolIndex].GetBuffer();
         }
 
         public void AddBuffer(byte[] buffer)
@@ -56,12 +54,12 @@ namespace TcpServiceCore.Buffering
 
             var length = buffer.Length;
 
-            if (length < minSize || length > this.MaxBufferSize)
+            if (length < minSize || length > MaxBufferSize)
                 return;
 
             var fitPoolIndex = (int)Math.Ceiling((double)length / minSize);
 
-            this.pools[fitPoolIndex].AddBuffer(buffer);
+            pools[fitPoolIndex].AddBuffer(buffer);
         }
     }
 }

--- a/src/TcpServiceCore/Buffering/BufferManagerMode.cs
+++ b/src/TcpServiceCore/Buffering/BufferManagerMode.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace TcpServiceCore.Buffering
+﻿namespace TcpServiceCore.Buffering
 {
     public enum BufferManagerMode
     {

--- a/src/TcpServiceCore/Buffering/BufferPool.cs
+++ b/src/TcpServiceCore/Buffering/BufferPool.cs
@@ -1,14 +1,11 @@
 ﻿using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace TcpServiceCore.Buffering
 {
     public class BufferPool
     {
-        Queue<byte[]> buffers = new Queue<byte[]>();
+        readonly Queue<byte[]> buffers = new Queue<byte[]>();
 
         public readonly int BufferSize;
         public readonly int PoolSize;
@@ -16,8 +13,8 @@ namespace TcpServiceCore.Buffering
 
         public BufferPool(int bufferSize, int poolSize)
         {
-            var bsn = nameof(bufferSize);
-            var psn = nameof(poolSize);
+            const string bsn = nameof(bufferSize);
+            const string psn = nameof(poolSize);
             if (bufferSize <= 0)
                 throw new Exception($"{bsn} must be positive greater than 0");
             if (poolSize <= 0)
@@ -25,24 +22,24 @@ namespace TcpServiceCore.Buffering
             if (poolSize < bufferSize)
                 throw new Exception($"{psn} can not be less than {bsn}");
 
-            this.BufferSize = bufferSize;
-            this.PoolSize = poolSize;
-            this.MaxBuffersCount = (int)Math.Floor((double)this.PoolSize / this.BufferSize);
+            BufferSize = bufferSize;
+            PoolSize = poolSize;
+            MaxBuffersCount = (int)Math.Floor((double)PoolSize / BufferSize);
         }
 
         public byte[] GetBuffer()
         {
-            byte[] buffer = null;
-            lock (this.buffers)
+            byte[] buffer;
+            lock (buffers)
             {
-                if (this.buffers.Count == 0)
+                if (buffers.Count == 0)
                 {
-                    buffer = new byte[this.BufferSize];
-                    this.buffers.Enqueue(buffer);
+                    buffer = new byte[BufferSize];
+                    buffers.Enqueue(buffer);
                 }
                 else
                 {
-                    buffer = this.buffers.Dequeue();
+                    buffer = buffers.Dequeue();
                 }
             }
             return buffer;
@@ -50,16 +47,16 @@ namespace TcpServiceCore.Buffering
 
         public void AddBuffer(byte[] buffer)
         {
-            if (buffer == null || buffer.Length != this.BufferSize)
+            if (buffer == null || buffer.Length != BufferSize)
                 return;
 
-            if (this.buffers.Count < this.MaxBuffersCount)
+            if (buffers.Count < MaxBuffersCount)
             {
-                lock (this.buffers)
+                lock (buffers)
                 {
-                    if (this.buffers.Count < this.MaxBuffersCount)
+                    if (buffers.Count < MaxBuffersCount)
                     {
-                        this.buffers.Enqueue(buffer);
+                        buffers.Enqueue(buffer);
                     }
                 }
             }

--- a/src/TcpServiceCore/Buffering/DummyBufferManager.cs
+++ b/src/TcpServiceCore/Buffering/DummyBufferManager.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace TcpServiceCore.Buffering
+﻿namespace TcpServiceCore.Buffering
 {
     public class DummyBufferManager : IBufferManager
     {

--- a/src/TcpServiceCore/Buffering/IBufferManager.cs
+++ b/src/TcpServiceCore/Buffering/IBufferManager.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace TcpServiceCore.Buffering
+﻿namespace TcpServiceCore.Buffering
 {
     public interface IBufferManager
     {

--- a/src/TcpServiceCore/Client/ChannelFactory.cs
+++ b/src/TcpServiceCore/Client/ChannelFactory.cs
@@ -1,12 +1,10 @@
-﻿using TcpServiceCore.Attributes;
-using TcpServiceCore.Communication;
+﻿using TcpServiceCore.Communication;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
-using System.Text;
 using System.Threading.Tasks;
 using TcpServiceCore.Dispatching;
 
@@ -14,7 +12,7 @@ namespace TcpServiceCore.Client
 {
     public static class ChannelFactory<T>
     {
-        static Type ImplementingType;
+        static readonly Type ImplementingType;
         static Type ProxyType;
 
         static ChannelFactory()
@@ -60,7 +58,7 @@ namespace TcpServiceCore.Client
 
             var ctor = builder.DefineConstructor(MethodAttributes.Public,
                 CallingConventions.HasThis,
-                new Type[] { channel.FieldType });
+                new[] { channel.FieldType });
 
             var il = ctor.GetILGenerator();
             il.Emit(OpCodes.Ldarg_0);
@@ -86,7 +84,7 @@ namespace TcpServiceCore.Client
                     ImplementInterface(_interface, builder, channel);
                 }
 
-                IEnumerable<MethodOperation> operations = null;
+                IEnumerable<MethodOperation> operations;
                 var intInfo = interfaceType.GetTypeInfo();
 
                 if (ContractHelper.IsContract(intInfo))
@@ -111,7 +109,7 @@ namespace TcpServiceCore.Client
                     il.Emit(OpCodes.Ldarg_0);
                     il.Emit(OpCodes.Ldfld, channel);
 
-                    MethodInfo invoke = null;
+                    MethodInfo invoke;
                     //implement the user interface
                     if (operation.IsOperation)
                     {

--- a/src/TcpServiceCore/Client/ClientCallbackHandler.cs
+++ b/src/TcpServiceCore/Client/ClientCallbackHandler.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Net.Sockets;
 using System.Threading.Tasks;
 using TcpServiceCore.Protocol;

--- a/src/TcpServiceCore/Client/ClientChannel.cs
+++ b/src/TcpServiceCore/Client/ClientChannel.cs
@@ -1,58 +1,53 @@
 ﻿using TcpServiceCore.Communication;
 using TcpServiceCore.Protocol;
 using TcpServiceCore.Tools;
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace TcpServiceCore.Client
 {
     public class ClientChannel<T> : CommunicationObject, IClientChannel
     {
-        InnerProxy<T> _InnerProxy;
-        IMsgIdProvider _IdProvider;
-        string _contract;
+        readonly InnerProxy<T> _InnerProxy;
+        readonly IMsgIdProvider _IdProvider;
+        readonly string _contract;
         public ClientChannel(string server, int port, ChannelConfig config)
         {
-            this._InnerProxy = new InnerProxy<T>(server, port, config);
-            this._IdProvider = Global.IdProvider;
-            this._contract = typeof(T).FullName;
+            _InnerProxy = new InnerProxy<T>(server, port, config);
+            _IdProvider = Global.IdProvider;
+            _contract = typeof(T).FullName;
         }
 
         protected override Task OnOpen()
         {
-            return this._InnerProxy.Open();
+            return _InnerProxy.Open();
         }
 
         protected override Task OnClose()
         {
-            return this._InnerProxy.Close();
+            return _InnerProxy.Close();
         }
 
         public Task SendOneWay(string method, params object[] msg)
         {
             var request = new Request(0, _contract, method, msg);
-            return this._InnerProxy.SendOneWay(request);
+            return _InnerProxy.SendOneWay(request);
         }
 
         public Task SendVoid(string method, params object[] msg)
         {
-            var request = this.CreateRequest(method, msg);
-            return this._InnerProxy.SendVoid(request);
+            var request = CreateRequest(method, msg);
+            return _InnerProxy.SendVoid(request);
         }
 
         public Task<R> SendReturn<R>(string method, params object[] msg)
         {
-            var request = this.CreateRequest(method, msg);
-            return this._InnerProxy.SendReturn<R>(request);
+            var request = CreateRequest(method, msg);
+            return _InnerProxy.SendReturn<R>(request);
         }
 
         Request CreateRequest(string method, params object[] msg)
         {
-            var id = int.Parse(this._IdProvider.NewId());
+            var id = int.Parse(_IdProvider.NewId());
             return new Request(id, _contract, method, msg);
         }
     }

--- a/src/TcpServiceCore/Client/IClientChannel.cs
+++ b/src/TcpServiceCore/Client/IClientChannel.cs
@@ -1,9 +1,4 @@
 ﻿using TcpServiceCore.Communication;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace TcpServiceCore.Client
 {

--- a/src/TcpServiceCore/Client/InnerProxy.cs
+++ b/src/TcpServiceCore/Client/InnerProxy.cs
@@ -1,12 +1,6 @@
 ﻿using TcpServiceCore.Communication;
 using TcpServiceCore.Protocol;
-using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Linq;
 using System.Net.Sockets;
-using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using TcpServiceCore.Tools;
 
@@ -14,53 +8,52 @@ namespace TcpServiceCore.Client
 {
     class InnerProxy<T> : CommunicationObject
     {
-        string server;
-        int port;
+        readonly string server;
+        readonly int port;
         TcpClient client;
         ResponseStreamHandler responseHandler;
-        ChannelConfig ChannelConfig;
+        readonly ChannelConfig ChannelConfig;
 
         public InnerProxy(string server, int port, ChannelConfig channelConfig)
         {
-            var type = typeof(T);
             this.server = server;
             this.port = port;
-            this.ChannelConfig = channelConfig;
-            this.Init();
+            ChannelConfig = channelConfig;
+            Init();
         }
 
         void Init()
         {
-            this.client = new TcpClient(AddressFamily.InterNetwork);
-            this.client.Configure(ChannelConfig);
-            this.responseHandler = new ResponseStreamHandler(this.client);
+            client = new TcpClient(AddressFamily.InterNetwork);
+            client.Configure(ChannelConfig);
+            responseHandler = new ResponseStreamHandler(client);
         }
 
         protected override async Task OnOpen()
         {
             await client.ConnectAsync(server, port);
-            await this.responseHandler.Open();
+            await responseHandler.Open();
         }
 
         protected override async Task OnClose()
         {
-            await this.responseHandler.Close();
+            await responseHandler.Close();
             client.Dispose();
         }
 
         public async Task SendOneWay(Request request)
         {
-            await this.responseHandler.WriteRequest(request);
+            await responseHandler.WriteRequest(request);
         }
 
         public async Task SendVoid(Request request)
         {
-            await this.responseHandler.WriteRequest(request, this.client.Client.ReceiveTimeout);
+            await responseHandler.WriteRequest(request, client.Client.ReceiveTimeout);
         }
 
         public async Task<R> SendReturn<R>(Request request)
         {
-            Response response = await this.responseHandler.WriteRequest(request, this.client.Client.ReceiveTimeout);
+            Response response = await responseHandler.WriteRequest(request, client.Client.ReceiveTimeout);
             var result = Global.Serializer.Deserialize<R>(response.Value);
             return result;
         }

--- a/src/TcpServiceCore/Communication/ChannelConfig.cs
+++ b/src/TcpServiceCore/Communication/ChannelConfig.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace TcpServiceCore.Communication
 {

--- a/src/TcpServiceCore/Communication/CommunicationObject.cs
+++ b/src/TcpServiceCore/Communication/CommunicationObject.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.CompilerServices;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace TcpServiceCore.Communication
@@ -11,9 +7,9 @@ namespace TcpServiceCore.Communication
     {
         public CommunicationState State { get; private set; }
 
-        public CommunicationObject()
+        protected CommunicationObject()
         {
-            this.State = CommunicationState.Created;
+            State = CommunicationState.Created;
         }
 
         protected abstract Task OnOpen();
@@ -24,25 +20,25 @@ namespace TcpServiceCore.Communication
         {
             lock (this)
             {
-                if (this.State != CommunicationState.Created)
+                if (State != CommunicationState.Created)
                     throw new Exception($"Can not open channel when its state is {State.ToString()}");
-                this.State = CommunicationState.Openning;
+                State = CommunicationState.Openning;
             }
             try
             {
-                await this.OnOpen();
+                await OnOpen();
                 lock (this)
                 {
-                    if (this.State != CommunicationState.Openning)
+                    if (State != CommunicationState.Openning)
                         throw new Exception($"Can not open channel when its state is {State.ToString()}");
-                    this.State = CommunicationState.Opened;
+                    State = CommunicationState.Opened;
                 }
             }
             catch (Exception)
             {
                 lock (this)
                 {
-                    this.State = CommunicationState.Faulted;
+                    State = CommunicationState.Faulted;
                     throw;
                 }
             }
@@ -52,25 +48,25 @@ namespace TcpServiceCore.Communication
         {
             lock (this)
             {
-                if(this.State < CommunicationState.Opened)
+                if(State < CommunicationState.Opened)
                     throw new Exception($"Can not close channel when its state is {State.ToString()}");
-                this.State = CommunicationState.Closing;
+                State = CommunicationState.Closing;
             }
             try
             {
-                await this.OnClose();
+                await OnClose();
                 lock (this)
                 {
-                    if (this.State != CommunicationState.Closing)
+                    if (State != CommunicationState.Closing)
                         throw new Exception($"Can not close channel when its state is {State.ToString()}");
-                    this.State = CommunicationState.Closed;
+                    State = CommunicationState.Closed;
                 }
             }
             catch (Exception)
             {
                 lock (this)
                 {
-                    this.State = CommunicationState.Faulted;
+                    State = CommunicationState.Faulted;
                     throw;
                 }
             }
@@ -78,12 +74,12 @@ namespace TcpServiceCore.Communication
 
         public virtual async Task Abort()
         {
-            await this.OnClose();
+            await OnClose();
         }
 
         public async void Dispose()
         {
-            await this.Abort();
+            await Abort();
         }
     }
 }

--- a/src/TcpServiceCore/Communication/CommunicationState.cs
+++ b/src/TcpServiceCore/Communication/CommunicationState.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace TcpServiceCore.Communication
+﻿namespace TcpServiceCore.Communication
 {
     public enum CommunicationState
     {

--- a/src/TcpServiceCore/Communication/ICommunicationObject.cs
+++ b/src/TcpServiceCore/Communication/ICommunicationObject.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace TcpServiceCore.Communication

--- a/src/TcpServiceCore/Dispatching/ContractHelper.cs
+++ b/src/TcpServiceCore/Dispatching/ContractHelper.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 using System.Reflection;
 using TcpServiceCore.Attributes;
 
@@ -23,7 +22,8 @@ namespace TcpServiceCore.Dispatching
 
             var operations = contractType.GetMethods()
                                 .Where(x => x.GetCustomAttribute<OperationContractAttribute>() != null)
-                                .Select(x => new MethodOperation(x));
+                                .Select(x => new MethodOperation(x))
+                                .ToList(); 
             
             foreach (var op in operations)
             {

--- a/src/TcpServiceCore/Dispatching/IInstanceContextFactory.cs
+++ b/src/TcpServiceCore/Dispatching/IInstanceContextFactory.cs
@@ -1,9 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Net.Sockets;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace TcpServiceCore.Dispatching
 {

--- a/src/TcpServiceCore/Dispatching/InstanceContext.cs
+++ b/src/TcpServiceCore/Dispatching/InstanceContext.cs
@@ -1,11 +1,4 @@
 ﻿using TcpServiceCore.Protocol;
-using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Net.Sockets;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace TcpServiceCore.Dispatching
@@ -19,28 +12,20 @@ namespace TcpServiceCore.Dispatching
 
         public InstanceContext(TypeDispatcher<T> dispatcher)
         {
-            this.Dispatcher = dispatcher;
-            this.Service = this.Dispatcher.CreateInstance();
+            Dispatcher = dispatcher;
+            Service = Dispatcher.CreateInstance();
         }
 
         public async Task HandleRequest(Request request, IRequestHandler requestHandler)
         {           
-            var operation = this.Dispatcher.GetOperation(request.Operation);
+            var operation = Dispatcher.GetOperation(request.Operation);
 
-            var result = await operation.Execute(this.Service, request);
+            var result = await operation.Execute(Service, request);
 
             if (operation.IsOneWay == false)
             {
-                Response resp = null;
-                if (operation.IsVoidTask)
-                {
-                    resp = new Response(request.Id, false, (byte)1);
-                }
-                else
-                {
-                    resp = new Response(request.Id, false, result);
-                }
-                await requestHandler.WriteResponse(resp);
+              var resp = operation.IsVoidTask ? new Response(request.Id, false, (byte)1) : new Response(request.Id, false, result);
+              await requestHandler.WriteResponse(resp);
             }
         }
     }

--- a/src/TcpServiceCore/Dispatching/InstanceContextFactory.cs
+++ b/src/TcpServiceCore/Dispatching/InstanceContextFactory.cs
@@ -1,10 +1,6 @@
 ﻿using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Linq;
 using System.Net.Sockets;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace TcpServiceCore.Dispatching
 {
@@ -12,10 +8,10 @@ namespace TcpServiceCore.Dispatching
     {
         public event Action<T> ServiceInstantiated;
         //Create instace context, no static so we can have two hosts in one application
-        ConcurrentDictionary<TcpClient, InstanceContext<T>> contexts =
+        readonly ConcurrentDictionary<TcpClient, InstanceContext<T>> contexts =
             new ConcurrentDictionary<TcpClient, InstanceContext<T>>();
 
-        object _lock = new object();
+        readonly object _lock = new object();
 
         InstanceContext<T> Singleton;
 
@@ -45,7 +41,7 @@ namespace TcpServiceCore.Dispatching
             }
             if (InstanceContext<T>.Current != result)
             {
-                this.ServiceInstantiated?.Invoke(result.Service);
+                ServiceInstantiated?.Invoke(result.Service);
             }
             InstanceContext<T>.Current = result;
             return result;

--- a/src/TcpServiceCore/Dispatching/InstanceMode.cs
+++ b/src/TcpServiceCore/Dispatching/InstanceMode.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace TcpServiceCore.Dispatching
+﻿namespace TcpServiceCore.Dispatching
 {
     public enum InstanceContextMode
     {

--- a/src/TcpServiceCore/Dispatching/TypeDispatcher.cs
+++ b/src/TcpServiceCore/Dispatching/TypeDispatcher.cs
@@ -1,17 +1,14 @@
 ﻿using TcpServiceCore.Attributes;
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace TcpServiceCore.Dispatching
 {
     class TypeDispatcher<T> where T: new()
     {
-        static object _lock = new object();
+        static readonly object _lock = new object();
         static TypeDispatcher<T> instance;
         
         public static TypeDispatcher<T> Instance
@@ -35,17 +32,17 @@ namespace TcpServiceCore.Dispatching
         private TypeDispatcher()
         {
             var type = typeof(T);
-            this.InstanceContextMode = InstanceContextMode.PerCall;
+            InstanceContextMode = InstanceContextMode.PerCall;
 
             var serviceBehavior = type.GetTypeInfo().GetCustomAttribute<ServiceBehaviorAttribute>(false);
             if (serviceBehavior != null)
             {
-                this.InstanceContextMode = serviceBehavior.InstanceContextMode;
+                InstanceContextMode = serviceBehavior.InstanceContextMode;
             }
 
             GetOperations(type);
             
-            if (this.OperationDispatchers.Count == 0)
+            if (OperationDispatchers.Count == 0)
                 throw new Exception("No OperationContract found");
         }
 
@@ -60,7 +57,7 @@ namespace TcpServiceCore.Dispatching
                     var operations = ContractHelper.ValidateContract(intInfo);
                     if (operations != null)
                     {
-                        this.OperationDispatchers.AddRange(operations);
+                        OperationDispatchers.AddRange(operations);
                     }
                     GetOperations(intfc);
                 }
@@ -74,7 +71,7 @@ namespace TcpServiceCore.Dispatching
 
         public MethodOperation GetOperation(string name)
         {
-            return this.OperationDispatchers.FirstOrDefault(x => x.TypeQualifiedName == name);
+            return OperationDispatchers.FirstOrDefault(x => x.TypeQualifiedName == name);
         }
     }
 }

--- a/src/TcpServiceCore/Exceptions/ExceptionHandler.cs
+++ b/src/TcpServiceCore/Exceptions/ExceptionHandler.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace TcpServiceCore.Exceptions
 {

--- a/src/TcpServiceCore/Global.cs
+++ b/src/TcpServiceCore/Global.cs
@@ -2,11 +2,6 @@
 using TcpServiceCore.Serialization;
 using TcpServiceCore.Serialization.Protobuf;
 using TcpServiceCore.Tools;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace TcpServiceCore
 {

--- a/src/TcpServiceCore/Properties/AssemblyInfo.cs
+++ b/src/TcpServiceCore/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following

--- a/src/TcpServiceCore/Protocol/IRequestHandler.cs
+++ b/src/TcpServiceCore/Protocol/IRequestHandler.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using TcpServiceCore.Communication;
 
 namespace TcpServiceCore.Protocol

--- a/src/TcpServiceCore/Protocol/IResponseHandler.cs
+++ b/src/TcpServiceCore/Protocol/IResponseHandler.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using TcpServiceCore.Communication;
 
 namespace TcpServiceCore.Protocol

--- a/src/TcpServiceCore/Protocol/ProtocolConstants.cs
+++ b/src/TcpServiceCore/Protocol/ProtocolConstants.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace TcpServiceCore.Protocol
+﻿namespace TcpServiceCore.Protocol
 {
     static class ProtocolConstants
     {

--- a/src/TcpServiceCore/Protocol/Request.cs
+++ b/src/TcpServiceCore/Protocol/Request.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace TcpServiceCore.Protocol
+﻿namespace TcpServiceCore.Protocol
 {
     class Request
     {
@@ -18,13 +12,10 @@ namespace TcpServiceCore.Protocol
 
         public Request(int id, string contract, string operation, object parameter)
         {
-            this.Id = id;
-            this.Contract = contract;
-            this.Operation = operation;
-            if (parameter is byte[])
-                this.Parameter = (byte[])parameter;
-            else
-                this.Parameter = Global.Serializer.Serialize(parameter);
+            Id = id;
+            Contract = contract;
+            Operation = operation;
+            Parameter = parameter as byte[] ?? Global.Serializer.Serialize(parameter);
         }
     }
 }

--- a/src/TcpServiceCore/Protocol/RequestStreamHandler.cs
+++ b/src/TcpServiceCore/Protocol/RequestStreamHandler.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Net.Sockets;
 using System.Text;
@@ -10,8 +9,7 @@ namespace TcpServiceCore.Protocol
 {
     abstract class RequestStreamHandler : StreamHandler, IRequestHandler
     {
-        public RequestStreamHandler(TcpClient client)
-            : base(client)
+        protected RequestStreamHandler(TcpClient client) : base(client)
         {
 
         }
@@ -20,7 +18,7 @@ namespace TcpServiceCore.Protocol
         public async Task<Request> GetRequest()
         {
             var index = 0;
-            var data = await this.Read();
+            var data = await Read();
 
             var id = BitConverter.ToInt32(data, index);
 
@@ -56,15 +54,15 @@ namespace TcpServiceCore.Protocol
             data.AddRange(BitConverter.GetBytes(response.IsError));
             data.AddRange(response.Value);
 
-            await this.Write(data.ToArray());
+            await Write(data.ToArray());
         }
 
         protected abstract Task OnRequestReceived(Request request);
 
         protected override async Task OnRead()
         {
-            var request = await this.GetRequest();
-            await this.OnRequestReceived(request);
+            var request = await GetRequest();
+            await OnRequestReceived(request);
         }
     }
 }

--- a/src/TcpServiceCore/Protocol/Response.cs
+++ b/src/TcpServiceCore/Protocol/Response.cs
@@ -1,11 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.Serialization;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace TcpServiceCore.Protocol
+﻿namespace TcpServiceCore.Protocol
 {
     class Response
     {
@@ -17,12 +10,10 @@ namespace TcpServiceCore.Protocol
 
         public Response(int id, bool isError, object value)
         {
-            this.Id = id;
-            this.IsError = IsError;
-            if (value is byte[])
-                this.Value = (byte[])value;
-            else
-                this.Value = Global.Serializer.Serialize(value);
+            Id = id;
+            IsError = isError;
+            var bytes = value as byte[];
+            Value = bytes ?? Global.Serializer.Serialize(value);
         }
 
         public Response()

--- a/src/TcpServiceCore/Serialization/ISerializer.cs
+++ b/src/TcpServiceCore/Serialization/ISerializer.cs
@@ -1,9 +1,4 @@
-﻿using TcpServiceCore.Protocol;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System;
 
 namespace TcpServiceCore.Serialization
 {

--- a/src/TcpServiceCore/Serialization/Json/JsonSerializer.cs
+++ b/src/TcpServiceCore/Serialization/Json/JsonSerializer.cs
@@ -1,9 +1,6 @@
 ﻿using Newtonsoft.Json;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 
 namespace TcpServiceCore.Serialization.Json
 {

--- a/src/TcpServiceCore/Serialization/Protobuf/ProtoSerializer.cs
+++ b/src/TcpServiceCore/Serialization/Protobuf/ProtoSerializer.cs
@@ -1,10 +1,6 @@
 ﻿using ProtoBuf;
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace TcpServiceCore.Serialization.Protobuf
 {

--- a/src/TcpServiceCore/Server/ServerRequestHandler.cs
+++ b/src/TcpServiceCore/Server/ServerRequestHandler.cs
@@ -12,9 +12,9 @@ namespace TcpServiceCore.Server
 {
     class ServerRequestHandler<T> : RequestStreamHandler where T: new()
     {
-        IInstanceContextFactory<T> instanceContextFactory;
+        readonly IInstanceContextFactory<T> instanceContextFactory;
 
-        Dictionary<string, ChannelConfig> channelConfigs;
+        readonly Dictionary<string, ChannelConfig> channelConfigs;
         bool isAccepted;
 
         public ServerRequestHandler(TcpClient client, 
@@ -36,12 +36,12 @@ namespace TcpServiceCore.Server
             {
                 var contract = request.Contract;
                 if (string.IsNullOrEmpty(contract))
-                    throw new Exception($"Wrong socket initialization, Request.Contract should not be null or empty");
-                var channelConfig = this.channelConfigs.FirstOrDefault(x => x.Key == contract);
+                    throw new Exception("Wrong socket initialization, Request.Contract should not be null or empty");
+                var channelConfig = channelConfigs.FirstOrDefault(x => x.Key == contract);
                 if (channelConfig.Value == null)
                     throw new Exception($"Wrong socket initialization, contract {contract} is missing");
 
-                this.Client.Configure(channelConfig.Value);
+                Client.Configure(channelConfig.Value);
 
                 await DoHandleRequest(request);
 
@@ -51,7 +51,7 @@ namespace TcpServiceCore.Server
 
         async Task DoHandleRequest(Request request)
         {
-            var context = this.instanceContextFactory.Create(this.Client);
+            var context = instanceContextFactory.Create(Client);
             await context.HandleRequest(request, this);
         }
     }

--- a/src/TcpServiceCore/Tools/IMsgIdProvider.cs
+++ b/src/TcpServiceCore/Tools/IMsgIdProvider.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace TcpServiceCore.Tools
+﻿namespace TcpServiceCore.Tools
 {
     public interface IMsgIdProvider
     {

--- a/src/TcpServiceCore/Tools/SimpleIdProvider.cs
+++ b/src/TcpServiceCore/Tools/SimpleIdProvider.cs
@@ -1,15 +1,11 @@
 ﻿using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace TcpServiceCore.Tools
 {
     class SimpleIdProvider : IMsgIdProvider
     {
-        ConcurrentQueue<string> queue = new ConcurrentQueue<string>();
+        readonly ConcurrentQueue<string> queue = new ConcurrentQueue<string>();
         string id;
         public SimpleIdProvider(string id = null)
         {

--- a/src/TcpServiceCore/Tools/SocketExtensions.cs
+++ b/src/TcpServiceCore/Tools/SocketExtensions.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net.Sockets;
-using System.Threading.Tasks;
+﻿using System.Net.Sockets;
 using TcpServiceCore.Communication;
 
 namespace TcpServiceCore.Tools


### PR DESCRIPTION
I've done a (mostly) automatic cleanup of the code, such as removing redundant 'this' qualifiers, making fields readonly and parameters with default variables, etc.

To my knowledge, there's only a couple of places where I may have changed the functionality:
- src/TcpServiceCore/Dispatching/ContractHelper.cs now turns the var operations = contractType.GetMethods() into a list, mostly to shut up ReSharper. R# noticed that the operations would be enumerated multiple times.
- src/TcpServiceCore/Protocol/Response.cs: I think I fixed a bug, where IsError was being assigned to itself and not the incomming value.
- src/TcpServiceCore/Server/ServiceHost.cs: I've changed handler.Open(); to await handler.Open();
